### PR TITLE
Add multi-question layout and new quizzes

### DIFF
--- a/assets/moon.svg
+++ b/assets/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M21 12.79A9 9 0 0111.21 3 7 7 0 0012 21a9 9 0 009-8.21z"/>
+</svg>

--- a/assets/sun.svg
+++ b/assets/sun.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <circle cx="12" cy="12" r="5"/>
+  <g stroke="currentColor" stroke-width="2">
+    <line x1="12" y1="1" x2="12" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="23" />
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+    <line x1="1" y1="12" x2="3" y2="12" />
+    <line x1="21" y1="12" x2="23" y2="12" />
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -72,6 +72,91 @@
                     </div>
                 </div>
             </a>
+
+            <!-- Card for Quiz 3 -->
+            <a href="quiz3.html" class="quiz-card" data-quiz-id="madar_quiz_3">
+                <div class="card-content">
+                    <h2>מבחן 3: בעיות תנאי קשות</h2>
+                    <p>תרגול מערכות קשוחות, אינטגרלים מסובכים ושיטות אנרגיה.</p>
+                </div>
+                <div class="card-footer">
+                    <div class="progress-bar-container">
+                        <div class="progress-bar"></div>
+                    </div>
+                    <div class="quiz-stats">
+                        <span class="status-badge"></span>
+                        <span class="score"></span>
+                    </div>
+                </div>
+            </a>
+
+            <!-- Card for Quiz 4 -->
+            <a href="quiz4.html" class="quiz-card" data-quiz-id="madar_quiz_4">
+                <div class="card-content">
+                    <h2>מבחן 4: סדרות ופתרונות אסימפטוטיים</h2>
+                    <p>שאלות מעמיקות על פתרון בעזרת טורים ושיטות הצמדת אנרגיה.</p>
+                </div>
+                <div class="card-footer">
+                    <div class="progress-bar-container">
+                        <div class="progress-bar"></div>
+                    </div>
+                    <div class="quiz-stats">
+                        <span class="status-badge"></span>
+                        <span class="score"></span>
+                    </div>
+                </div>
+            </a>
+
+            <!-- Card for Quiz 5 -->
+            <a href="quiz5.html" class="quiz-card" data-quiz-id="madar_quiz_5">
+                <div class="card-content">
+                    <h2>מבחן 5: משוואות לא לינאריות מתקדמות</h2>
+                    <p>ניתוח מערכות כאוטיות והתנהגות גבולית של פתרונות.</p>
+                </div>
+                <div class="card-footer">
+                    <div class="progress-bar-container">
+                        <div class="progress-bar"></div>
+                    </div>
+                    <div class="quiz-stats">
+                        <span class="status-badge"></span>
+                        <span class="score"></span>
+                    </div>
+                </div>
+            </a>
+
+            <!-- Card for Quiz 6 -->
+            <a href="quiz6.html" class="quiz-card" data-quiz-id="madar_quiz_6">
+                <div class="card-content">
+                    <h2>מבחן 6: התמרות מתקדמות</h2>
+                    <p>שאלות קשות על התמרת לפלס, פרנל והתמרות נוספות.</p>
+                </div>
+                <div class="card-footer">
+                    <div class="progress-bar-container">
+                        <div class="progress-bar"></div>
+                    </div>
+                    <div class="quiz-stats">
+                        <span class="status-badge"></span>
+                        <span class="score"></span>
+                    </div>
+                </div>
+            </a>
+
+            <!-- Card for Quiz 7 -->
+            <a href="quiz7.html" class="quiz-card" data-quiz-id="madar_quiz_7">
+                <div class="card-content">
+                    <h2>מבחן 7: בעיות גבול ויציבות</h2>
+                    <p>פתרון בעיות קצה לא רגילות וניתוח יציבות של מערכות.</p>
+                </div>
+                <div class="card-footer">
+                    <div class="progress-bar-container">
+                        <div class="progress-bar"></div>
+                    </div>
+                    <div class="quiz-stats">
+                        <span class="status-badge"></span>
+                        <span class="score"></span>
+                    </div>
+                </div>
+            </a>
         </main>
     </div>
 

--- a/quiz3.html
+++ b/quiz3.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>מבחן 3: בעיות תנאי קשות</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;600;700&family=Rubik:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>
+</head>
+<body data-quiz-id="madar_quiz_3">
+    <div class="quiz-container">
+        <div class="quiz-header-bar">
+            <a href="index.html" class="back-link">חזרה לתפריט הראשי</a>
+            <div id="quiz-progress-display"></div>
+            <button id="dark-mode-toggle" title="שנה מצב תצוגה">
+                <img id="theme-icon" src="assets/sun.svg" alt="theme icon" />
+            </button>
+        </div>
+        <header>
+            <h1>מבחן 3: בעיות תנאי קשות</h1>
+            <p>כל השאלות בדף אחד. בהצלחה!</p>
+        </header>
+        <main id="question-area"></main>
+        <div id="quiz-results" class="quiz-results" style="display:none;"></div>
+    </div>
+    <script>
+    const quizData = [
+        {
+            question: "פתור את בעיית התנאי \(y''+y=0\), \(y(0)=0\), \(y(\pi/2)=1\)",
+            equation: "",
+            options: [
+                { text: "\\(y=\\sin x\\)", correct: true },
+                { text: "\\(y=\\cos x\\)", correct: false },
+                { text: "\\(y=2\\sin x\\)", correct: false },
+                { text: "\\(y=\\sin x+\\cos x\\)", correct: false },
+                { text: "\\(y=0\\)", correct: false }
+            ],
+            explanation: "הפתרון הכללי הוא \(y=A\\sin x + B\\cos x\). מהתנאים נקבל \(B=0\) ו-\(A=1\)."
+        },
+        {
+            question: "מה יציבות נקודת שווי המשקל של \(\dot x=-x^3\)?",
+            equation: "",
+            options: [
+                { text: "יציבה", correct: true },
+                { text: "לא יציבה", correct: false },
+                { text: "נייטרלית", correct: false },
+                { text: "מחזורית", correct: false },
+                { text: "אין נקודה כזו", correct: false }
+            ],
+            explanation: "הנגזרת סביב 0 היא שלילית ולכן הנקודה יציבה אסימפטוטית."
+        },
+        {
+            question: "חשב את התמרת לפלס של \(t^2 e^{3t}\)",
+            equation: "",
+            options: [
+                { text: "\\(2/(s-3)^3\\)", correct: true },
+                { text: "\\(6/(s-3)^2\\)", correct: false },
+                { text: "\\(2/(s+3)^3\\)", correct: false },
+                { text: "\\(1/(s-3)^2\\)", correct: false },
+                { text: "\\(6/(s+3)^3\\)", correct: false }
+            ],
+            explanation: "נשתמש בנוסחה הכללית \(\mathcal{L}\{t^n e^{at}\}= n!/(s-a)^{n+1}\)."
+        },
+        {
+            question: "מהם הערכים העצמיים של המטריצה \(\begin{pmatrix}0&1\\\\-4&-4\end{pmatrix}\)?",
+            equation: "",
+            options: [
+                { text: "0,-4", correct: false },
+                { text: "-2,-2", correct: true },
+                { text: "2,-2", correct: false },
+                { text: "4,-4", correct: false },
+                { text: "1,-4", correct: false }
+            ],
+            explanation: "הפולינום האופייני הוא \(r^2+4r+4=(r+2)^2\)."
+        },
+        {
+            question: "איזה גורם אינטגרציה מתאים למשוואה \((2x-y)dx+(x+3y)dy=0\)?",
+            equation: "",
+            options: [
+                { text: "\\(e^{2x}\\)", correct: true },
+                { text: "x^2", correct: false },
+                { text: "y^2", correct: false },
+                { text: "1/x", correct: false },
+                { text: "אין גורם כזה", correct: false }
+            ],
+            explanation: "נמצא \(\mu(x)=e^{\int (M_y-N_x)/N\,dx}=e^{2x}\)."
+        },
+        {
+            question: "פתור את משוואת קושי–אוילר \(x^2 y'' + x y' - y = 0\)",
+            equation: "",
+            options: [
+                { text: "\\(y=C_1 x + C_2 x^{-1}\\)", correct: true },
+                { text: "\\(y=C_1 x^2 + C_2\\)", correct: false },
+                { text: "\\(y=C_1 e^{x}+C_2 e^{-x}\\)", correct: false },
+                { text: "\\(y=C_1 x^{-2}+C_2 x^2\\)", correct: false },
+                { text: "\\(y=C_1\\cos x + C_2\\sin x\\)", correct: false }
+            ],
+            explanation: "מציבים \(y=x^r\) ומקבלים \(r^2-1=0\Rightarrow r=\pm1\)."
+        }
+    ];
+    </script>
+    <script src="logic.js"></script>
+</body>
+</html>

--- a/quiz4.html
+++ b/quiz4.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>מבחן 4: סדרות ופתרונות אסימפטוטיים</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;600;700&family=Rubik:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>
+</head>
+<body data-quiz-id="madar_quiz_4">
+    <div class="quiz-container">
+        <div class="quiz-header-bar">
+            <a href="index.html" class="back-link">חזרה לתפריט הראשי</a>
+            <div id="quiz-progress-display"></div>
+            <button id="dark-mode-toggle" title="שנה מצב תצוגה">
+                <img id="theme-icon" src="assets/sun.svg" alt="theme icon" />
+            </button>
+        </div>
+        <header>
+            <h1>מבחן 4: סדרות ופתרונות אסימפטוטיים</h1>
+            <p>כל השאלות בדף אחד. בהצלחה!</p>
+        </header>
+        <main id="question-area"></main>
+        <div id="quiz-results" class="quiz-results" style="display:none;"></div>
+    </div>
+    <script>
+    const quizData = [
+        {
+            question: "מהו האיבר המוביל בפתרון האסימפטוטי של משוואת Airy \(y''-xy=0\) כאשר \(x\to\infty\)?",
+            equation: "",
+            options: [
+                { text: "\\(y\\sim C x^{-1/4} e^{-\tfrac{2}{3}x^{3/2}}\\)", correct: true },
+                { text: "\\(y\\sim C e^{x^2}\\)", correct: false },
+                { text: "\\(y\\sim C x\\)", correct: false },
+                { text: "\\(y\\sim C \\ln x\\)", correct: false },
+                { text: "\\(y\\sim C x^{1/2}\\)", correct: false }
+            ],
+            explanation: "הפתרון הדועך של משוואת Airy מתנהג כ\\(x^{-1/4}e^{-\tfrac{2}{3}x^{3/2}}\\)."
+        },
+        {
+            question: "למשוואה \(y''-xy=0\) נחפש פתרון טורי סביב \(x=0\). מה ערך \(a_2\) אם \(y=\sum a_n x^n\)?",
+            equation: "",
+            options: [
+                { text: "0", correct: true },
+                { text: "1", correct: false },
+                { text: "-1/2", correct: false },
+                { text: "2", correct: false },
+                { text: "-2", correct: false }
+            ],
+            explanation: "מאחר והמשוואה כוללת רק איבר \(xy\), מקבלים \(a_2=0\)."
+        },
+        {
+            question: "מה רדיוס ההתכנסות של הטור \(\sum_{n=0}^\infty \frac{x^{2n}}{(2n)!}\)?",
+            equation: "",
+            options: [
+                { text: "אינסופי", correct: true },
+                { text: "1", correct: false },
+                { text: "2", correct: false },
+                { text: "1/2", correct: false },
+                { text: "אין התכנסות", correct: false }
+            ],
+            explanation: "זהו הטור של \(\cosh x\) ולכן רדיוס ההתכנסות אינסופי."
+        },
+        {
+            question: "נתונות שתי פתרונות \(y_1,y_2\) של משוואה לינארית. מהו ה-Wronskian \(W(y_1,y_2)\) אם ידוע כי הפתרון היחיד הוא טריוויאלי?",
+            equation: "",
+            options: [
+                { text: "0", correct: true },
+                { text: "1", correct: false },
+                { text: "y_1 y_2' - y_1' y_2", correct: false },
+                { text: "תמיד קבוע חיובי", correct: false },
+                { text: "תלוי ב-\\(x\\)", correct: false }
+            ],
+            explanation: "אם כל הפתרונות תלויים לינארית, ה-Wronskian מתאפס."
+        },
+        {
+            question: "באיזה תנאי גבול מתאפס הפתרון הזוגי של \(y''+\lambda y=0\) בקטע \([0,\pi]\)?",
+            equation: "",
+            options: [
+                { text: "\\(y'(0)=0, y'(\pi)=0\\)", correct: true },
+                { text: "\\(y(0)=0, y(\pi)=0\\)", correct: false },
+                { text: "\\(y(0)=1, y'(\pi)=0\\)", correct: false },
+                { text: "\\(y'(0)=1, y(\pi)=0\\)", correct: false },
+                { text: "ללא תנאים", correct: false }
+            ],
+            explanation: "פתרון זוגי מחייב תנאי נגזרת מתאפסים בקצוות."
+        },
+        {
+            question: "מהו סוג הסינגולריות של הפונקציה \(f(x)=\frac{1}{x^2}\) בנקודה \(x=0\)?",
+            equation: "",
+            options: [
+                { text: "יחידה חיובית", correct: true },
+                { text: "חבויה", correct: false },
+                { text: "קפיצה", correct: false },
+                { text: "הסירה", correct: false },
+                { text: "אין סינגולריות", correct: false }
+            ],
+            explanation: "ל-f יש קוטב מדרגה 2 ולכן זהו סינגולרית יחידה."
+        }
+    ];
+    </script>
+    <script src="logic.js"></script>
+</body>
+</html>

--- a/quiz5.html
+++ b/quiz5.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>מבחן 5: משוואות לא לינאריות מתקדמות</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;600;700&family=Rubik:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>
+</head>
+<body data-quiz-id="madar_quiz_5">
+    <div class="quiz-container">
+        <div class="quiz-header-bar">
+            <a href="index.html" class="back-link">חזרה לתפריט הראשי</a>
+            <div id="quiz-progress-display"></div>
+            <button id="dark-mode-toggle" title="שנה מצב תצוגה">
+                <img id="theme-icon" src="assets/sun.svg" alt="theme icon" />
+            </button>
+        </div>
+        <header>
+            <h1>מבחן 5: משוואות לא לינאריות מתקדמות</h1>
+            <p>כל השאלות בדף אחד. בהצלחה!</p>
+        </header>
+        <main id="question-area"></main>
+        <div id="quiz-results" class="quiz-results" style="display:none;"></div>
+    </div>
+    <script>
+    const quizData = [
+        {
+            question: "פתור את משוואת ריקאטי \(y' = y^2 - x\)",
+            equation: "",
+            options: [
+                { text: "\\(y= -1/x\\)", correct: false },
+                { text: "\\(y= x\\)", correct: false },
+                { text: "\\(y= -\\tfrac{1}{x} + x\\)", correct: true },
+                { text: "\\(y= x^2\\)", correct: false },
+                { text: "\\(y=0\\)", correct: false }
+            ],
+            explanation: "ננחש פתרון בצורת פולינום ומקבלים \(y=-1/x+x\)."
+        },
+        {
+            question: "מה סוג נקודת שיווי המשקל ב-\((0,0)\) למערכת \(\dot x = y,\; \dot y = -x + x^3\)?",
+            equation: "",
+            options: [
+                { text: "אוכף", correct: true },
+                { text: "מוקד יציב", correct: false },
+                { text: "מוקד לא יציב", correct: false },
+                { text: "מרכז", correct: false },
+                { text: "אין נקודה כזו", correct: false }
+            ],
+            explanation: "הליניאריזציה נותנת ערכים עצמיים ממשיים הפוכים ולכן זוהי נקודת אוכף."
+        },
+        {
+            question: "פתור בקירוב ראשון את \(y' = y - y^3\) עבור \(y(0)=\epsilon\ll1\)",
+            equation: "",
+            options: [
+                { text: "\\(y(t) \approx \epsilon e^{t}\\)", correct: true },
+                { text: "\\(y(t) \approx \epsilon e^{-t}\\)", correct: false },
+                { text: "\\(y(t) \approx \epsilon^3 e^{t}\\)", correct: false },
+                { text: "\\(y(t) \approx \epsilon e^{t^2}\\)", correct: false },
+                { text: "\\(y(t) \approx 0\\)", correct: false }
+            ],
+            explanation: "לערך התחלתי קטן ההתנהגות ראשונה היא מעריכית עם מקדם 1."
+        },
+        {
+            question: "מהו זמן הקריסה המשוער לפתרון \(y' = y^2\) עם \(y(0)=1\)?",
+            equation: "",
+            options: [
+                { text: "1", correct: true },
+                { text: "1/2", correct: false },
+                { text: "2", correct: false },
+                { text: "אין קריסה", correct: false },
+                { text: "-1", correct: false }
+            ],
+            explanation: "האינטגרציה נותנת \(y = 1/(1-t)\) ולכן הקריסה ב-\(t=1\)."
+        },
+        {
+            question: "איזו פונקציית ליאפונוב מתאימה ל-\(\dot x = -x^3\)?",
+            equation: "",
+            options: [
+                { text: "\\(V=\tfrac{1}{2}x^2\\)", correct: true },
+                { text: "\\(V=x\\)", correct: false },
+                { text: "\\(V=x^4\\)", correct: false },
+                { text: "\\(V=\tfrac{1}{2}x\\)", correct: false },
+                { text: "אין פונקציה כזו", correct: false }
+            ],
+            explanation: "בחירה סטנדרטית היא \(V=\tfrac{1}{2}x^2\) שמקיימת \(\dot V \le 0\)."
+        },
+        {
+            question: "מהי התנהגות הפתרון ל-\(y''+y^3=0\) עבור תנאים התחלתיים קטנים?",
+            equation: "",
+            options: [
+                { text: "מתנד קרוב להרמוני", correct: true },
+                { text: "מעריכי", correct: false },
+                { text: "כאוטי", correct: false },
+                { text: "קבוע", correct: false },
+                { text: "בלתי יציב מיד", correct: false }
+            ],
+            explanation: "לערכים קטנים מתקבל תנוד דומה למתנד הרמוני עם תיקונים קטנים."
+        }
+    ];
+    </script>
+    <script src="logic.js"></script>
+</body>
+</html>

--- a/quiz6.html
+++ b/quiz6.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>מבחן 6: התמרות מתקדמות</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;600;700&family=Rubik:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>
+</head>
+<body data-quiz-id="madar_quiz_6">
+    <div class="quiz-container">
+        <div class="quiz-header-bar">
+            <a href="index.html" class="back-link">חזרה לתפריט הראשי</a>
+            <div id="quiz-progress-display"></div>
+            <button id="dark-mode-toggle" title="שנה מצב תצוגה">
+                <img id="theme-icon" src="assets/sun.svg" alt="theme icon" />
+            </button>
+        </div>
+        <header>
+            <h1>מבחן 6: התמרות מתקדמות</h1>
+            <p>כל השאלות בדף אחד. בהצלחה!</p>
+        </header>
+        <main id="question-area"></main>
+        <div id="quiz-results" class="quiz-results" style="display:none;"></div>
+    </div>
+    <script>
+    const quizData = [
+        {
+            question: "חשב את התמרת לפלס של פונקציית המדרגה היחידתית \(u(t-1)\)",
+            equation: "",
+            options: [
+                { text: "\\(e^{-s}/s\\)", correct: true },
+                { text: "\\(1/s\\)", correct: false },
+                { text: "\\(e^{-s}\\)", correct: false },
+                { text: "\\(s e^{-s}\\)", correct: false },
+                { text: "0", correct: false }
+            ],
+            explanation: "תמרת המדרגה היא \(e^{-s}/s\)."
+        },
+        {
+            question: "מצא את התמרת פורייה של \(e^{-a|t|}\) עבור \(a>0\)",
+            equation: "",
+            options: [
+                { text: "\\(\\tfrac{2a}{a^2+\omega^2}\\)", correct: true },
+                { text: "\\(\\tfrac{a}{a^2+\omega^2}\\)", correct: false },
+                { text: "\\(\\tfrac{1}{a^2+\omega^2}\\)", correct: false },
+                { text: "\\(\\tfrac{2}{a^2+\omega^2}\\)", correct: false },
+                { text: "\\(\\tfrac{a^2}{\omega^2}\\)", correct: false }
+            ],
+            explanation: "התמרת פורייה הידועה של פונקציה זו שווה ל-\(\tfrac{2a}{a^2+\omega^2}\)."
+        },
+        {
+            question: "מהי ההתמרה ההפוכה של \(\tfrac{s}{s^2+1}\)?",
+            equation: "",
+            options: [
+                { text: "\\cos t", correct: true },
+                { text: "\\sin t", correct: false },
+                { text: "e^{t}", correct: false },
+                { text: "1", correct: false },
+                { text: "t", correct: false }
+            ],
+            explanation: "התמרה הפוכה של \(s/(s^2+1)\) היא \(\cos t\)."
+        },
+        {
+            question: "איזה משפט מאפשר לחשב תמרת לפלס של כפל קונבולוציה?",
+            equation: "",
+            options: [
+                { text: "משפט הכפל", correct: false },
+                { text: "משפט ההזזה", correct: false },
+                { text: "משפט הקונבולוציה", correct: true },
+                { text: "משפט הדו-צדדי", correct: false },
+                { text: "אין משפט כזה", correct: false }
+            ],
+            explanation: "משפט הקונבולוציה קובע \(\mathcal{L}\{f*g\}=F(s)G(s)\)."
+        },
+        {
+            question: "מהי התמרת Z של \(a^n\) כאשר \(|z|>|a|\)?",
+            equation: "",
+            options: [
+                { text: "\\(\\tfrac{z}{z-a}\\)", correct: true },
+                { text: "\\(\\tfrac{1}{z-a}\\)", correct: false },
+                { text: "\\(\\tfrac{a}{z-a}\\)", correct: false },
+                { text: "\\(\\tfrac{z}{z+a}\\)", correct: false },
+                { text: "\\(\\tfrac{1}{z}\\)", correct: false }
+            ],
+            explanation: "תמרת Z הבסיסית ל-\(a^n\) היא \(z/(z-a)\)."
+        },
+        {
+            question: "איזה תנאי על \(F(s)\) מבטיח קיום התמרת לפלס הפוכה?",
+            equation: "",
+            options: [
+                { text: "גדילה מסדר מעריכי", correct: true },
+                { text: "מחזוריות", correct: false },
+                { text: "אפסיות באינסוף", correct: false },
+                { text: "תמיד קיימת", correct: false },
+                { text: "נגזרת רציפה", correct: false }
+            ],
+            explanation: "אם \(F(s)\) בעלת גבול מעריכי, קיימת התמרה הפוכה."
+        }
+    ];
+    </script>
+    <script src="logic.js"></script>
+</body>
+</html>

--- a/quiz7.html
+++ b/quiz7.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>מבחן 7: בעיות גבול ויציבות</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Assistant:wght@300;400;600;700&family=Rubik:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"></script>
+</head>
+<body data-quiz-id="madar_quiz_7">
+    <div class="quiz-container">
+        <div class="quiz-header-bar">
+            <a href="index.html" class="back-link">חזרה לתפריט הראשי</a>
+            <div id="quiz-progress-display"></div>
+            <button id="dark-mode-toggle" title="שנה מצב תצוגה">
+                <img id="theme-icon" src="assets/sun.svg" alt="theme icon" />
+            </button>
+        </div>
+        <header>
+            <h1>מבחן 7: בעיות גבול ויציבות</h1>
+            <p>כל השאלות בדף אחד. בהצלחה!</p>
+        </header>
+        <main id="question-area"></main>
+        <div id="quiz-results" class="quiz-results" style="display:none;"></div>
+    </div>
+    <script>
+    const quizData = [
+        {
+            question: "איזה תנאי דרישלה מתאים למשוואה \(y''+\lambda y=0\) בקטע \([0,L]\)?",
+            equation: "",
+            options: [
+                { text: "\\(y(0)=0, y(L)=0\\)", correct: true },
+                { text: "\\(y'(0)=0, y'(L)=0\\)", correct: false },
+                { text: "\\(y(0)=1, y'(L)=0\\)", correct: false },
+                { text: "\\(y'(0)=1, y(L)=0\\)", correct: false },
+                { text: "ללא תנאי", correct: false }
+            ],
+            explanation: "בעיית דרישלה דורשת ערכי פונקציה נתונים בשני הקצוות."
+        },
+        {
+            question: "למשוואה \(x''+2x'+5x=0\) מה ניתן לומר על יציבות הפתרון?",
+            equation: "",
+            options: [
+                { text: "יציב", correct: true },
+                { text: "לא יציב", correct: false },
+                { text: "נייטרלי", correct: false },
+                { text: "מחזורי", correct: false },
+                { text: "אין פתרון", correct: false }
+            ],
+            explanation: "הערכים העצמיים הם \(-1\pm2i\) ולכן הפתרון מתנד ודועך." 
+        },
+        {
+            question: "איזו שיטה מתאימה לפתרון בעיית ירי?",
+            equation: "",
+            options: [
+                { text: "ניחוש נגזרת התחלתי", correct: true },
+                { text: "אינטגרציה אנליטית מלאה", correct: false },
+                { text: "שיטת ההפרדה", correct: false },
+                { text: "אין שיטה כזו", correct: false },
+                { text: "שיטת גרדIENT", correct: false }
+            ],
+            explanation: "שיטת הירי משתמשת בניחוש על נגזרת ההתחלה כדי לעמוד בתנאי הקצה." 
+        },
+        {
+            question: "באיזו משוואה משתמשים לבדיקת יציבות ליאפונוב של מערכת \(\dot x=Ax\)?",
+            equation: "",
+            options: [
+                { text: "\\(A^TP+PA=-Q\\)", correct: true },
+                { text: "\\(AP=PA\\)", correct: false },
+                { text: "\\(A^2=Q\\)", correct: false },
+                { text: "\\(P'=-A\\)", correct: false },
+                { text: "אין קשר למטריצה P", correct: false }
+            ],
+            explanation: "משוואת ליאפונוב היא \(A^TP+PA=-Q\)." 
+        },
+        {
+            question: "מהו ערך האינקסטרום המינימלי של פונקציה בבעיית ריצ'רדסון?",
+            equation: "",
+            options: [
+                { text: "אפס", correct: true },
+                { text: "גדול מאפס", correct: false },
+                { text: "שלילי", correct: false },
+                { text: "אינסופי", correct: false },
+                { text: "לא מוגדר", correct: false }
+            ],
+            explanation: "בבעיות גבול רבות ערך זה הוא אפס לקבלת פתרון לא טריוויאלי." 
+        },
+        {
+            question: "אם \(y''+qy=0\) ושני הפתרונות מתאפסים בקצה אחד, מה נובע?",
+            equation: "",
+            options: [
+                { text: "הפתרונות תלויים לינארית", correct: true },
+                { text: "הפתרונות אורתוגונליים", correct: false },
+                { text: "המערכת יציבה", correct: false },
+                { text: "אין פתרון כלל", correct: false },
+                { text: "הפתרון מחזורי", correct: false }
+            ],
+            explanation: "שני פתרונות המתאפסים יחד באותה נקודה תלויים לינארית." 
+        }
+    ];
+    </script>
+    <script src="logic.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show all questions simultaneously instead of one at a time
- keep score as user answers and reveal final results at bottom
- add dark‑mode icons
- include five new tough quizzes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686a1f4388988323b67a2d73b383171b